### PR TITLE
Add package to release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: "windows-latest"
 
     steps:
-
+    
+      - uses: actions/checkout@v2
+      - name: "Clone"
+        run: Echo "cloning"
+        
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
I missed the step that actually adds the package to the release... This should work now it worked on my fork.

You could also make github build the package without having to build it yourself, here is how I did it : 

 https://github.com/sharkoz/keypirinha-outlook_calendar/blob/main/.github/workflows/main.yml